### PR TITLE
Add isort configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,11 @@ charset = utf-8
 [*.py]
 indent_size = 4
 indent_style = space
+# isort-specific settings
+atomic = true
+force_sort_within_sections = true
+include_trailing_comma = true
+multi_line_output = 3
 
 [*.y{,a}ml]
 indent_size = 2

--- a/redirect.py
+++ b/redirect.py
@@ -1,5 +1,5 @@
-import os
 from datetime import datetime
+import os
 from wsgiref.simple_server import make_server
 from wsgiref.types import StartResponse, WSGIEnvironment
 


### PR DESCRIPTION
There are a few things about the default configuration that I don't
like, so this will:

* Only change a file if it's syntax is valid
* Sort by import path rather than type
* Use hanging vertical identation
* Include trailing commas