### PR TITLE
Fix the types

### DIFF
--- a/redirect.py
+++ b/redirect.py
@@ -1,10 +1,10 @@
 from datetime import datetime
 import os
+from typing import List
 from wsgiref.simple_server import make_server
-from wsgiref.types import StartResponse, WSGIEnvironment
 
 
-def app(environ: WSGIEnvironment, start_response: StartResponse):
+def app(environ, start_response) -> List[bytes]:
     current_year = os.environ.get("PYGOTHAM_YEAR", datetime.now().year)
     url = f"https://{current_year}.pygotham.org"
     start_response("302 Moved Temporarily", [("Location", url)])


### PR DESCRIPTION
`WSGIEnviron` and `StartResponse` are defined in
[typeshed](https://github.com/python/typeshed) and can't be imported
into code. This is currently causing a `ModuleNotFound` error. Because
we don't control the values passed to these arguments anyway, there
isn't much value in typing them.

The one thing we do control, though, is the return value. This was left
untyped. Adding a type here ensures that what we return is the correct
shape.