### PR TITLE
Sort imports on a line alphabetically

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,7 @@ indent_size = 4
 indent_style = space
 # isort-specific settings
 atomic = true
+force_alphabetical_sort = true
 force_sort_within_sections = true
 include_trailing_comma = true
 multi_line_output = 3


### PR DESCRIPTION
isort wants to sort things by type (constant, class, function, etc.)
before sorting them by name. I prefer to have everything listed
alphabetically to make the imports easier to scan.