### PR TITLE
Restore app's argument types

### DIFF
--- a/redirect.py
+++ b/redirect.py
@@ -1,10 +1,13 @@
 from datetime import datetime
 import os
-from typing import List
+from typing import List, TYPE_CHECKING
 from wsgiref.simple_server import make_server
 
+if TYPE_CHECKING:
+    from wsgiref.types import StartResponse, WSGIEnvironment
 
-def app(environ, start_response) -> List[bytes]:
+
+def app(environ: "WSGIEnvironment", start_response: "StartResponse") -> List[bytes]:
     current_year = os.environ.get("PYGOTHAM_YEAR", datetime.now().year)
     url = f"https://{current_year}.pygotham.org"
     start_response("302 Moved Temporarily", [("Location", url)])


### PR DESCRIPTION
f0a8eddefdad4e7874dae2b9ff6f212f3b941003 removed the types from `app`'s
arguments because the types themselves only exist within
[typeshed](https://github.com/python/typeshed). The only time they can
be imported it when type checking the code. Fortunately there's a
convention for doing this sort of thing. The types are being added back
with the import behind an if that will never be true at runtime.