### PR TITLE
Only support numeric subdomains

### DIFF
--- a/redirect.py
+++ b/redirect.py
@@ -8,7 +8,10 @@ if TYPE_CHECKING:
 
 
 def app(environ: "WSGIEnvironment", start_response: "StartResponse") -> List[bytes]:
-    current_year = os.environ.get("PYGOTHAM_YEAR", datetime.now().year)
+    try:
+        current_year = int(os.environ["PYGOTHAM_YEAR"])
+    except (KeyError, ValueError):
+        current_year = datetime.now().year
     url = f"https://{current_year}.pygotham.org"
     start_response("302 Moved Temporarily", [("Location", url)])
     return [url.encode()]


### PR DESCRIPTION
This project will redirect to whatever subdomain is specified in the
`PYGOTHAM_YEAR` environment variable. A bad value (e.g., `example.com/`)
could send visitors to an unexpected destination.

Rather than doing that, we should take advantage of the fact that
`pygotham.org` will redirect to a year-specific site and only support
numeric values, falling back to the current year whenever the value
isn't found or is non-numeric.

Closes #7