### PR TITLE
Test that the module can be imported

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,3 +22,7 @@ jobs:
       - name: Run hooks
         run: |
           pre-commit run --all-files
+
+      - name: Run tests
+        run: |
+          tox

--- a/README.md
+++ b/README.md
@@ -33,3 +33,10 @@ automatically before you commit it.
 $ pip3 install -r dev-requirements.txt
 $ pre-commit install
 ```
+
+While linting and fixing will happen as part of pre-commit hooks, there is a
+test suite that can be run as well.
+
+```
+$ tox
+```

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,2 @@
 pre-commit
+tox

--- a/test_redirect.py
+++ b/test_redirect.py
@@ -1,0 +1,5 @@
+import importlib
+
+
+def test_that_redirect_can_be_imported() -> None:
+    importlib.import_module("redirect")

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py38
+skipsdist = true
+
+[testenv]
+deps =
+    pytest
+commands =
+    pytest .


### PR DESCRIPTION
21aefad92bb1bd47a08dd8982c96b25dc0ee0c54 broke the ability to import
`redirect` and took down the production installation of it. A test that
the module can be imported is being added to prevent this from happening
again.

Closes #8