### PR TITLE
Clean up the pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/timothycrosley/isort
-    rev: master
+    rev: 4.3.21
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 19.10b0
     hooks:
       - id: black
         language_version: python3.8


### PR DESCRIPTION
[pre-commit](https://pre-commit.com) likes to use immutable revisions
for hooks (as opposed to things like branch names or `HEAD`). This is
the result of running `pre-commit autoupdate`.