### PR TITLE
Add pre-commit hook to remove unused imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
 repos:
+  - repo: https://github.com/humitos/mirrors-autoflake
+    rev: v1.3
+    hooks:
+      - id: autoflake
+        args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']
   - repo: https://github.com/timothycrosley/isort
     rev: 4.3.21
     hooks:


### PR DESCRIPTION
A [pre-commit](https://pre-commit.com) hook is being added to run
[autoflake](https://pypi.org/p/autoflake) to remove any unused imports
that get left behind.